### PR TITLE
Use action's master branch, allow manual dispatch

### DIFF
--- a/.github/workflows/build_animation.yml
+++ b/.github/workflows/build_animation.yml
@@ -4,6 +4,7 @@ on:
   push:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 jobs:
   record:
     runs-on: ubuntu-latest
@@ -11,7 +12,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Record and deploy the animation
-        uses: pal-admin/webots-animation-action@feature-competition-calibration
+        uses: pal-admin/webots-animation-action@master
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_PAT_KEY: ${{ secrets.BOT_PAT_KEY }}


### PR DESCRIPTION
This is a follow-up to upstream https://github.com/cyberbotics/webots-animation-action/pull/12 merged into the action's master branch. Additionally, I propose that manually triggered jobs are allowed on this workflow for testing purposes (see [GH docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github)).